### PR TITLE
WIP: Vimb

### DIFF
--- a/bucket_47/vimb/distinfo
+++ b/bucket_47/vimb/distinfo
@@ -1,0 +1,1 @@
+5c6fe39b1b2ca18a342bb6683f7fd5b139ead53903f57dd9eecd5a1074576d6c       136151 fanglingsu-vimb-3.3.0.tar.gz

--- a/bucket_47/vimb/manifests/plist.single
+++ b/bucket_47/vimb/manifests/plist.single
@@ -1,0 +1,4 @@
+bin/vimb
+lib/vimb/webext_main.so
+share/applocations/vimb.desktop
+share/man/man1/vimb.1.gz

--- a/bucket_47/vimb/specification
+++ b/bucket_47/vimb/specification
@@ -1,0 +1,33 @@
+DEF[PORTVERSION]=	3.3.0
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		vimb
+VERSION=		${PORTVERSION}
+KEYWORDS=		www
+VARIANTS=		standard
+SDESC[standard]=	Vim-like browser
+HOMEPAGE=		https://fanglingsu.github.io/vimb/
+CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		GITHUB/fanglingsu:vimb:${PORTVERSION}
+DISTFILE[1]=		generated:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		GPLv3+:single
+LICENSE_FILE=		GPLv3+:{{WRKSRC}}/LICENSE
+LICENSE_TERMS=		single:{{WRKDIR}}/TERMS
+LICENSE_AWK=		TERMS:"^\#include"
+LICENSE_SOURCE=		TERMS:{{WRKSRC}}/src/main.c
+LICENSE_SCHEME=		solo
+
+FPC_EQUIVALENT=		www/vimb-gtk3
+
+USES=			desktop-utils:single gmake pkgconfig
+BUILDRUN_DEPENDS=	webkit2:single:gtk3
+CFLAGS=			-D_BSD_SOURCE
+MAKE_ENV=		V=1


### PR DESCRIPTION
The port is basically ready, but it fails to compile with weird error:
```
cc main.o
cc -I/raven/include -DVERSION=\"3.2.0\" -DEXTENSIONDIR=\"/raven/lib/vimb\" -DCOMMIT=\"unknown\" -DPROJECT=\"vimb\" -DPROJECT_UCFIRST=\"Vimb\" -D_XOPEN
_SOURCE=500 -D__BSD_VISIBLE -DGSEAL_ENABLE -DGTK_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DVERSION=\"3.2.0\" -DEXTENSIONDIR=\"/raven/lib/vimb
\" -DCOMMIT=\"unknown\" -DPROJECT=\"vimb\" -DPROJECT_UCFIRST=\"Vimb\" -D_XOPEN_SOURCE=500 -D__BSD_VISIBLE -DGSEAL_ENABLE -DGTK_DISABLE_SINGLE_INCLUDES
 -DGDK_DISABLE_DEPRECATED -pipe -O2  -D_BSD_SOURCE -I/raven/include -std=c99 -pipe -Wall -fPIC -I/raven/include/gtk-3.0 -I/raven/include/pango-1.0 -I/
raven/include/glib-2.0 -I/raven/lib/glib-2.0/include -I/raven/include -I/raven/lib/libffi-3.2.1/include -I/raven/include/fribidi -I/raven/include/cair
o -I/raven/include/pixman-1 -I/raven/include/freetype2 -I/raven/include/uuid -I/raven/include/libdrm -I/raven/include/libpng16 -I/raven/include/harfbu
zz -I/raven/include/gdk-pixbuf-2.0 -D_THREAD_SAFE -I/raven/include/gio-unix-2.0 -D_THREAD_SAFE -I/raven/include/atk-1.0 -I/raven/include/at-spi2-atk/2
.0 -I/raven/include/at-spi-2.0 -I/raven/include/dbus-1.0 -I/raven/lib/dbus-1.0/include -I/raven/include/webkitgtk-4.0 -D_THREAD_SAFE -D_THREAD_SAFE -D
_THREAD_SAFE -D_THREAD_SAFE -I/raven/include/libsoup-2.4 -pthread -I/raven/include/libxml2  -std=c99 -pipe -Wall -fPIC -I/raven/include/gtk-3.0 -I/rav
en/include/pango-1.0 -I/raven/include/glib-2.0 -I/raven/lib/glib-2.0/include -I/raven/include -I/raven/lib/libffi-3.2.1/include -I/raven/include/fribi
di -I/raven/include/cairo -I/raven/include/pixman-1 -I/raven/include/freetype2 -I/raven/include/uuid -I/raven/include/libdrm -I/raven/include/libpng16
 -I/raven/include/harfbuzz -I/raven/include/gdk-pixbuf-2.0 -D_THREAD_SAFE -I/raven/include/gio-unix-2.0 -D_THREAD_SAFE -I/raven/include/atk-1.0 -I/rav
en/include/at-spi2-atk/2.0 -I/raven/include/at-spi-2.0 -I/raven/include/dbus-1.0 -I/raven/lib/dbus-1.0/include -I/raven/include/webkitgtk-4.0 -D_THREA
D_SAFE -D_THREAD_SAFE -D_THREAD_SAFE -D_THREAD_SAFE -I/raven/include/libsoup-2.4 -pthread -I/raven/include/libxml2  -c -o main.o main.c
In file included from /raven/include/glib-2.0/glib/gtypes.h:35,
                 from /raven/include/glib-2.0/glib/galloca.h:32,
                 from /raven/include/glib-2.0/glib.h:30,
                 from /raven/include/gtk-3.0/gdk/gdkconfig.h:13,
                 from /raven/include/gtk-3.0/gdk/gdk.h:30,
                 from /raven/include/gtk-3.0/gdk/gdkx.h:28,
                 from main.c:20:
/usr/include/time.h:211:25: error: expected ')' before 'lwpid_t'
 int getcpuclockid(pid_t, lwpid_t, clockid_t *);
                         ^~~~~~~~
                         )
```